### PR TITLE
Fix #9: implement rescale, window, and modality_lut ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ coverage.xml
 
 # data
 unittest-data/
+notebooks/


### PR DESCRIPTION
Add support for common operations on medical images, such as `apply_window`, `apply_modality_lut` and `apply_rescale`. The names and functionality of these ops is slightly different from pydicom. Most notably, `apply_modality_lut` will not try to perform an `apply_rescale` operation.