### PR TITLE
Fix #4: add an HttpReader class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ nibabel
 packaging
 pydicom>=1.6.0
 PyYAML>=5.4.1
+requests
 tabulate
 termcolor
 tqdm>=4.42.0

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ REQUIRED = [
     "packaging",
     "pydicom>=1.6.0",
     "PyYAML>=5.4.1",
+    "requests",
     "tabulate",
     "termcolor",
     "tqdm>=4.42.0",
@@ -110,6 +111,7 @@ EXTRAS = {
         # testing.
         "pytest-cov>=2.10.1",
         "pre-commit>=2.9.3",
+        "requests-mock",
         # upload.
         "twine",
     ],

--- a/tests/io/test_format_io_utils.py
+++ b/tests/io/test_format_io_utils.py
@@ -78,11 +78,6 @@ def test_read():
     assert vol.is_identical(expected)
 
     dcm_data = os.path.join(pydd.get_testdata_file("MR_small.dcm"))
-    vol = vx.read(dcm_data, unpack=True)
-    expected = DicomReader().load(dcm_data)
-    assert vol.is_identical(expected)
-
-    dcm_data = os.path.join(pydd.get_testdata_file("MR_small.dcm"))
     vol = vx.read(dcm_data, group_by="EchoNumbers")[0]
     expected = DicomReader(group_by="EchoNumbers").load(dcm_data)[0]
     assert vol.is_identical(expected)

--- a/tests/io/test_http_io.py
+++ b/tests/io/test_http_io.py
@@ -1,0 +1,127 @@
+import os
+import unittest
+import zipfile
+from io import BytesIO
+
+import nibabel.testing as nib_testing
+import requests_mock as rm
+from pydicom.data import get_testdata_file
+
+import voxel as vx
+from voxel.io.dicom import DicomReader
+from voxel.io.format_io import ImageDataFormat
+from voxel.io.http import HttpReader
+from voxel.io.nifti import NiftiReader
+
+
+class TestHttpIO(unittest.TestCase):
+    nr = NiftiReader()
+    dr = DicomReader()
+
+    def test_load_nifti(self):
+        """Test with nibabel sample data."""
+        base_url = "https://test.com"
+
+        # NIfTI1 file
+        fname = "example4d.nii.gz"
+        filepath = os.path.join(nib_testing.data_path, fname)
+        mv_nifti1 = self.nr.load(filepath)
+
+        with open(filepath, "rb") as f:
+            file_nifti1 = f.read()
+
+        with rm.Mocker() as m:
+            m.get(f"{base_url}/{fname}", content=file_nifti1)
+            with HttpReader() as hr:
+                mv = hr.load(f"{base_url}/{fname}")
+                assert mv.is_identical(mv_nifti1)
+
+        # NIfTI2 file
+        fname = "example_nifti2.nii.gz"
+        filepath = os.path.join(nib_testing.data_path, fname)
+        mv_nifti2 = self.nr.load(filepath)
+
+        with open(filepath, "rb") as f:
+            file_nifti2 = f.read()
+
+        with rm.Mocker() as m:
+            m.get(f"{base_url}/{fname}", content=file_nifti2)
+            m.get(f"{base_url}/test", content=file_nifti2)
+
+            hr = HttpReader()
+            mv = hr.load(f"{base_url}/{fname}")
+            assert mv.is_identical(mv_nifti2)
+
+            # Ambiguous file extension
+            with self.assertRaises(AttributeError):
+                hr.load(f"{base_url}/test")
+
+            with self.assertRaises(ValueError):
+                hr.load(f"{base_url}/test", data_format=ImageDataFormat.nifti)
+
+            mv = hr.load(f"{base_url}/test", data_format="nifti", compressed=True)
+            assert mv.is_identical(mv_nifti2)
+            hr.close()
+
+        # Nifti file with .nii extension
+        fname = "functional.nii"
+        filepath = os.path.join(nib_testing.data_path, fname)
+        mv_nifti = self.nr.load(filepath)
+
+        with open(filepath, "rb") as f:
+            file_nifti = f.read()
+
+        with rm.Mocker() as m:
+            m.get(f"{base_url}/{fname}", content=file_nifti)
+            mv = vx.load(f"{base_url}/{fname}")
+            assert mv.is_identical(mv_nifti)
+
+    def test_load_dicom(self):
+        """Test with DICOM sample data.
+
+        TODO: add tests for multipart/related
+        """
+        base_url = "https://test.com"
+
+        # Single DICOM file
+        fname = "CT_small.dcm"
+        filepath = get_testdata_file(fname)
+        mv_dicom = self.dr.load(filepath)
+
+        with open(filepath, "rb") as f:
+            file_dicom = f.read()
+
+        with rm.Mocker() as m:
+            m.get(f"{base_url}", content=file_dicom)
+            m.get(f"{base_url}/{fname}", content=file_dicom)
+
+            with HttpReader() as hr:
+                mv = hr.load(f"{base_url}")
+                assert mv.is_identical(mv_dicom)
+
+            mv = vx.load(f"{base_url}/{fname}")
+            assert mv.is_identical(mv_dicom)
+
+            with self.assertRaises(ValueError):
+                vx.load(f"{base_url}/{fname}", data_format="nifti")
+
+        # Zipped DICOM file(s)
+        zip_buffer = BytesIO()
+        with zipfile.ZipFile(zip_buffer, "a") as zf:
+            zf.writestr(fname, file_dicom)
+
+        with rm.Mocker() as m:
+            headers = {"Content-Type": "application/zip"}
+            m.get(f"{base_url}/file.zip", content=zip_buffer.getvalue(), headers=headers)
+
+            mv = vx.load(f"{base_url}/file.zip")
+            assert mv.is_identical(mv_dicom)
+
+            m.get(f"{base_url}/bad.zip", content=zip_buffer.getvalue())
+
+            with self.assertRaises(ValueError):
+                vx.load(f"{base_url}/bad.zip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/voxel/__init__.py
+++ b/voxel/__init__.py
@@ -3,6 +3,7 @@ from voxel.device import Device, cpu_device, get_array_module, get_device, to_de
 from voxel.io import load, read, save, write  # noqa: F401
 from voxel.io.dicom import DicomReader, DicomWriter  # noqa: F401
 from voxel.io.format_io import ImageDataFormat  # noqa: F401
+from voxel.io.http import HttpReader  # noqa: F401
 from voxel.io.nifti import NiftiReader, NiftiWriter  # noqa: F401
 from voxel.med_volume import MedicalVolume  # noqa: F401
 from voxel.orientation import to_affine  # noqa: F401
@@ -14,6 +15,7 @@ __all__ = [
     "MedicalVolume",
     "DicomReader",
     "DicomWriter",
+    "HttpReader",
     "NiftiReader",
     "NiftiWriter",
     "read",

--- a/voxel/io/http.py
+++ b/voxel/io/http.py
@@ -1,0 +1,250 @@
+"""
+HTTP I/O.
+
+This module contains HTTP input/output helpers.
+"""
+
+import re
+import zipfile
+from io import BytesIO
+from typing import Collection, Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+import numpy as np
+import requests
+from tqdm.auto import tqdm
+
+from voxel.io.dicom import DicomReader
+from voxel.io.format_io import DataReader, ImageDataFormat
+from voxel.io.nifti import NiftiReader
+
+__all__ = ["HttpReader"]
+
+
+_MIME_TYPES_ZIP = [
+    "application/zip",
+    "application/x-zip-compressed",
+    "multipart/x-zip",
+    "application/dicom+zip",
+]
+
+
+class HttpReader(DataReader):
+    """A class for reading DICOMs from HTTP requests with DICOMweb support.
+
+    Attributes:
+        verbose (bool, optional): If ``True``, show loading progress bar.
+        block_size (int, optional): Block size for reading data.
+        **kwargs: Keyword arguments for :class:`DicomReader`.
+
+    Examples:
+        >>> hr = HttpReader()
+        >>> hr.read("https://server.com/dicom.zip")
+        >>> hr.read("https://server.com/dicom.dcm")
+        >>> hr.read("https://server.com/dicom-web/studies/x/series/y")
+        >>> hr.close()
+
+        >>> with HttpReader() as hr:
+        >>>     hr.session.auth = ("username", "password")
+        >>>     hr.read("https://server.com/dicom", params={"x": "y"})
+    """
+
+    def __init__(self, verbose: bool = False, block_size: int = 10**6, **kwargs):
+        self.verbose = verbose
+        self.block_size = block_size
+        self.session = requests.Session()
+        self.pbar = None
+        self.kwargs = kwargs
+
+    def _read_multipart_stream(
+        self,
+        res: requests.Response,
+        content_info: str,
+    ) -> List[bytes]:
+        """Read multipart stream.
+
+        Args:
+            res (requests.Response): Response object.
+            content_info (str): Content info.
+            pbar (tqdm): Progress bar.
+        """
+        boundary = _extract_boundary(content_info)
+        blob, parts = bytes(), []
+
+        for block in res.iter_content(self.block_size):
+            self.pbar.update(len(block))
+
+            blob += block
+            while boundary in blob:
+                part, blob = blob.split(boundary, maxsplit=1)
+                content = _extract_part(part)
+
+                if content is not None:
+                    parts.append(content)
+
+        content = _extract_part(blob)
+        if content is not None:
+            parts.append(content)
+
+        self.pbar.close()
+        return parts
+
+    def _read_stream(self, res: requests.Response) -> bytes:
+        """Read stream.
+
+        Args:
+            res (requests.Response): Response object.
+            pbar (tqdm): Progress bar.
+        """
+
+        blob = bytes()
+        for block in res.iter_content(self.block_size):
+            self.pbar.update(len(block))
+            blob += block
+
+        self.pbar.close()
+        return blob
+
+    def _read_dicom(self, buffers: List[bytes], **kwargs):
+        """Read DICOMs from data.
+
+        Args:
+            buffers (List[bytes]): List of bytes objects.
+            **kwargs: Keyword arguments for :class:`DicomReader`.
+        """
+
+        # do not pass verbose to reader, as files are already opened
+        dr = DicomReader(**kwargs)
+        return dr.read([BytesIO(buffer) for buffer in buffers])
+
+    def _read_nifti(self, buffer: bytes, **kwargs):
+        """Read NIfTI from data.
+
+        Args:
+            buffer (bytes): Bytes
+            **kwargs: Keyword arguments for :class:`NiftiReader`.
+        """
+        nr = NiftiReader(**kwargs)
+        return nr.read(BytesIO(buffer))
+
+    def load(
+        self,
+        url: str,
+        params: Union[Dict, List[Tuple], bytes] = np._NoValue,
+        data_format: ImageDataFormat = None,
+        verbose: bool = None,
+        **kwargs,
+    ):
+        """Load data from HTTP request.
+
+        Args:
+            url (str): URL.
+            params (Union[Dict, List[Tuple], bytes], optional): Parameters to send with the request.
+            **kwargs: Keyword arguments for :class:`DicomReader`.
+        """
+
+        if not _is_valid_url(url):
+            raise IOError(f"Invalid URL: {url}.")
+
+        params = params if params != np._NoValue else self.session.params
+        with self.session.get(url, params=params, stream=True) as res:
+            content_length = res.headers.get("Content-Length", 0)
+            content_type = res.headers.get("Content-Type", "application/octet-stream").lower()
+
+            self.pbar = tqdm(
+                total=content_length,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                disable=not verbose if verbose is not None else not self.verbose,
+            )
+
+            # Mime: multipart/related, expect DICOM
+            if content_type.startswith("multipart/related;"):
+                _, *content_info = [part.strip() for part in content_type.split(";")]
+                parts = self._read_multipart_stream(res, content_info)
+                return self._read_dicom(parts, **kwargs)
+
+            # Mime: application/zip, expect DICOM
+            if content_type in _MIME_TYPES_ZIP:
+                blob = self._read_stream(res)
+                z = zipfile.ZipFile(BytesIO(blob))
+                parts = [z.read(zinfo) for zinfo in z.infolist() if zinfo.file_size > 0]
+                return self._read_dicom(parts, **kwargs)
+
+            # Fallback to single file, expect NiFTI or DICOM
+            blob = self._read_stream(res)
+            if data_format is None:
+                basename = urlparse(url).path
+                data_format = ImageDataFormat.get_image_data_format(basename)
+            elif isinstance(data_format, str):
+                data_format = ImageDataFormat[data_format]
+
+            if data_format == ImageDataFormat.nifti:
+                return self._read_nifti(blob, **kwargs)
+            elif data_format == ImageDataFormat.dicom:
+                return self._read_dicom([blob], **kwargs)
+            else:
+                raise IOError(f"Unsupported data format: {data_format}.")
+
+    def close(self):
+        """Close the current HTTP session."""
+        self.session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def __serializable_variables__(self) -> Collection[str]:
+        return self.__dict__.keys()
+
+    read = load  # pragma: no cover
+
+
+def _is_valid_url(url: str) -> bool:
+    """Check if a string represents a valid URL.
+
+    Args:
+        url (str): URL.
+
+    Returns:
+        bool: Result of the URL validation.
+    """
+    regex = re.compile(
+        r"^(?:http|ftp)s?://"  # http:// or https://
+        r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"
+        r"localhost|"  # localhost...
+        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+        r"(?::\d+)?"  # optional port
+        r"(?:/?|[/?]\S+)$",
+        re.IGNORECASE,
+    )
+
+    return re.match(regex, url) is not None
+
+
+def _extract_part(part: bytes) -> Union[bytes, None]:
+    """Extract part from multipart stream."""
+    if part in [b"", b"--", b"\r\n"] or part.startswith(b"--\r\n"):
+        return None
+
+    idx = part.index(b"\r\n\r\n")
+    if idx > -1:
+        return part[idx + 4 :]
+
+    raise ValueError("Part is not CRLF CRLF terminated.")
+
+
+def _extract_boundary(content_info: List[str]) -> Optional[bytes]:
+    """Extract boundary from content info."""
+    for item in content_info:
+        if "=" not in item:
+            continue
+
+        key, value = item.split("=", maxsplit=1)
+        if key.lower() == "boundary":
+            return b"--" + value.strip('"').encode("utf-8")
+
+    return None

--- a/voxel/io/http.py
+++ b/voxel/io/http.py
@@ -114,8 +114,8 @@ class HttpReader(DataReader):
         """
 
         # do not pass verbose to reader, as files are already opened
-        dr = DicomReader(**kwargs)
-        return dr.read([BytesIO(buffer) for buffer in buffers])
+        dr = DicomReader()
+        return dr.read([BytesIO(buffer) for buffer in buffers], **kwargs)
 
     def _read_nifti(self, buffer: bytes, **kwargs):
         """Read NIfTI from data.
@@ -124,8 +124,8 @@ class HttpReader(DataReader):
             buffer (bytes): Bytes
             **kwargs: Keyword arguments for :class:`NiftiReader`.
         """
-        nr = NiftiReader(**kwargs)
-        return nr.read(BytesIO(buffer))
+        nr = NiftiReader()
+        return nr.read(BytesIO(buffer), **kwargs)
 
     def load(
         self,
@@ -181,6 +181,8 @@ class HttpReader(DataReader):
                 data_format = ImageDataFormat[data_format]
 
             if data_format == ImageDataFormat.nifti:
+                if urlparse(url).path.endswith(".gz"):
+                    kwargs = {"compressed": True, **kwargs}
                 return self._read_nifti(blob, **kwargs)
             elif data_format == ImageDataFormat.dicom:
                 return self._read_dicom([blob], **kwargs)

--- a/voxel/io/nifti.py
+++ b/voxel/io/nifti.py
@@ -142,4 +142,6 @@ def _nifti_version(buffer: BytesIO) -> int:
         elif sizeof_hdr == nii2_sizeof_hdr:
             return 2
 
-    raise IOError("This buffer is not a valid NIfTI file.")
+    raise ValueError(
+        "This buffer is not a valid NIfTI file. Pass `compressed=True` if the buffer is gzipped."
+    )

--- a/voxel/io/nifti.py
+++ b/voxel/io/nifti.py
@@ -3,8 +3,10 @@
 This module contains NIfTI input/output helpers.
 """
 
+import gzip
 import os
-from typing import Collection
+from io import BytesIO
+from typing import Collection, Union
 
 import nibabel as nib
 
@@ -24,14 +26,22 @@ class NiftiReader(DataReader):
 
     data_format_code = ImageDataFormat.nifti
 
-    def load(self, file_path, mmap: bool = False) -> MedicalVolume:
+    def load(
+        self,
+        path_or_bytes: Union[str, bytes, os.PathLike, BytesIO],
+        mmap: bool = False,
+        compressed: bool = False,
+    ) -> MedicalVolume:
         """Load volume from NIfTI file path.
 
         A NIfTI file should only correspond to one volume.
 
         Args:
-            file_path (str): File path to NIfTI file.
+            path_or_bytes (Union[str, bytes, os.PathLike, BytesIO]): Path to NIfTI file or
+                bytes of NIfTI file.
             mmap (bool): Whether to use memory mapping.
+            compressed (bool): Whether to apply gzip decompression. This is only used if
+                `path_or_bytes` is a bytes or BytesIO object.
 
         Returns:
             MedicalVolume: Loaded volume.
@@ -40,15 +50,31 @@ class NiftiReader(DataReader):
             FileNotFoundError: If `file_path` not found.
             ValueError: If `file_path` does not end in a supported NIfTI extension.
         """
-        if not os.path.isfile(file_path):
-            raise FileNotFoundError("{} not found".format(file_path))
+        if isinstance(path_or_bytes, bytes):
+            path_or_bytes = BytesIO(path_or_bytes)
 
-        if not self.data_format_code.is_filetype(file_path):
-            raise ValueError(
-                "{} must be a file with extension '.nii' or '.nii.gz'".format(file_path)
-            )
+        if isinstance(path_or_bytes, BytesIO):
+            if compressed:
+                path_or_bytes = BytesIO(gzip.decompress(path_or_bytes.getvalue()))
 
-        nib_img = nib.load(file_path)
+            nifti_version = _nifti_version(path_or_bytes)
+            fh = nib.FileHolder(fileobj=path_or_bytes)
+            if nifti_version == 1:
+                nib_img = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
+            else:
+                nib_img = nib.Nifti2Image.from_file_map({"header": fh, "image": fh})
+
+        else:
+            if not os.path.isfile(path_or_bytes):
+                raise FileNotFoundError("{} not found".format(path_or_bytes))
+
+            if not self.data_format_code.is_filetype(path_or_bytes):
+                raise ValueError(
+                    "{} must be a file with extension '.nii' or '.nii.gz'".format(path_or_bytes)
+                )
+
+            nib_img = nib.load(path_or_bytes)
+
         return MedicalVolume.from_nib(
             nib_img,
             affine_precision=vx.config.affine_precision,
@@ -96,3 +122,24 @@ class NiftiWriter(DataWriter):
         return self.__dict__.keys()
 
     write = save  # pragma: no cover
+
+
+def _nifti_version(buffer: BytesIO) -> int:
+    """Get NIfTI version from buffer."""
+    nii1_sizeof_hdr = 348
+    nii2_sizeof_hdr = 540
+
+    byte_data = buffer.read(4)
+    sizeof_hdr = int.from_bytes(byte_data, byteorder="little")
+    if sizeof_hdr == nii1_sizeof_hdr:
+        return 1
+    elif sizeof_hdr == nii2_sizeof_hdr:
+        return 2
+    else:
+        sizeof_hdr = int.from_bytes(byte_data, byteorder="big")
+        if sizeof_hdr == nii1_sizeof_hdr:
+            return 1
+        elif sizeof_hdr == nii2_sizeof_hdr:
+            return 2
+
+    raise IOError("This buffer is not a valid NIfTI file.")


### PR DESCRIPTION
This PR adds an `HttpReader` class that enables users to load DICOM and NifTI files over HTTP(S). It also enables to load Nifti1 and Nifti2 images from objects in memory (`bytes` and `BytesIO`). This reader has support for DICOMweb and future zipped responses from DICOMweb. The latter is currently used by TCIA. 

```python
# Remote file loading
mv = vx.load("http://test.com/CT.dcm")

# Use the HttpReader to reuse the session
with HttpReader() as hr:
    hr.load("http://test.com/nifti.nii.gz")

# Verbose syntax
hr = HttpReader(verbose=True)
hr.load("https://test.com/path/to/multipart/dicoms")
hr.close()
```