### PR TITLE
support expanded arguments for reformat

### DIFF
--- a/tests/test_med_volume.py
+++ b/tests/test_med_volume.py
@@ -66,6 +66,12 @@ class TestMedicalVolume(unittest.TestCase):
         mv2 = mv.reformat(new_orientation).reformat(mv.orientation)
         assert mv2.is_identical(mv)
 
+        mv2 = mv.reformat(*new_orientation).reformat(*mv.orientation)
+        assert mv2.is_identical(mv)
+
+        with self.assertRaises(ValueError):
+            mv.reformat(new_orientation, True)
+
     def test_reformat_as(self):
         mv = MedicalVolume(np.random.rand(10, 20, 30), self._AFFINE)
         mv2 = MedicalVolume(np.random.rand(10, 20, 30), self._AFFINE[:, (0, 2, 1, 3)])

--- a/voxel/med_volume.py
+++ b/voxel/med_volume.py
@@ -183,7 +183,7 @@ class MedicalVolume(NDArrayOperatorsMixin):
         writer = vio.get_writer(data_format)
         writer.save(self, file_path)
 
-    def reformat(self, new_orientation: Sequence, inplace: bool = False) -> "MedicalVolume":
+    def reformat(self, new_orientation: Sequence, *args, inplace: bool = False) -> "MedicalVolume":
         """Reorients volume to a specified orientation.
 
         Flipping and transposing the volume array (``self.volume``) returns a view if possible.
@@ -216,6 +216,14 @@ class MedicalVolume(NDArrayOperatorsMixin):
         xp = self.device.xp
         device = self.device
         headers = self._headers
+
+        if len(args):
+            if any(isinstance(x, bool) for x in args):
+                raise ValueError(
+                    "`inplace` is a keyword only argument. Use `inplace=` to specify "
+                    "if the operation should be in-place."
+                )
+            new_orientation = (new_orientation, *args)
 
         new_orientation = tuple(new_orientation)
         if new_orientation == self.orientation:


### PR DESCRIPTION
These are now equivalent statements:

```python
# Equivalent
mv.reformat(("SI", "AP", "LR"))
mv.reformat("SI", "AP", "LR")

# In-place
mv.reformat(("SI", "AP", "LR"), inplace=True)
mv.reformat("SI", "AP", "LR", inplace=True)

# This will raise an error
# inplace must be a keyword arg
mv.reformat(("SI", "AP", "LR"), True)
```