### PR TITLE
Enhanced dicom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-exclude = '(\.eggs|\.git|\.github|.ipynb)'
+exclude = '(\.eggs|\.git|\.github|.ipynb|venv)'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,8 @@ follow_imports = silent
 allow_redefinition = True
 ; Require all functions to be annotated
 disallow_incomplete_defs = True
+
+[flake8]
+exclude=.git,__pycache__,build,dist,venv
+max_line_length=120
+ignore=E203,W503

--- a/tests/io/test_dicom_io.py
+++ b/tests/io/test_dicom_io.py
@@ -237,7 +237,7 @@ class TestDicomIO(ututils.TempPathMixin):
                         h1, h2
                     ), "headers for echoes %d must be equivalent" % (ind + 1)
 
-    @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
+    @unittest.skipIf(not ututils.is_data_available("qdess"), "unittest data is not available")
     def test_dicom_writer_nd(self):
         """Test writing dicoms for >3D MedicalVolume data."""
         dicom_path = ututils.get_dicoms_path(ututils.get_scan_dirpath("qdess"))
@@ -399,7 +399,7 @@ class TestDicomIO(ututils.TempPathMixin):
             instance_numbers = [h.InstanceNumber for h in v.headers(flatten=True)]
             assert instance_numbers == sorted(instance_numbers)
 
-    @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
+    @unittest.skipIf(not ututils.is_data_available("qdess"), "unittest data is not available")
     def test_write_sort_by(self):
         """Test sorting by dicom attributes before writing."""
         dp = ututils.get_scan_dirpath("qdess")
@@ -421,7 +421,7 @@ class TestDicomIO(ututils.TempPathMixin):
         assert e1.is_identical(vols[0])
         assert e2.is_identical(vols[1])
 
-    @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
+    @unittest.skipIf(not ututils.is_data_available("qdess"), "unittest data is not available")
     def test_load_no_group_by(self):
         """Test reading dicoms without group_by."""
         dp = ututils.get_scan_dirpath("qdess")
@@ -434,7 +434,7 @@ class TestDicomIO(ututils.TempPathMixin):
 
         assert e1.is_identical(e1_expected)
 
-    @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
+    @unittest.skipIf(not ututils.is_data_available("qdess"), "unittest data is not available")
     def test_init_params(self):
         """Test reading/writing works with passing values to constructor."""
         dp = ututils.get_scan_dirpath("qdess")

--- a/tests/test_med_volume.py
+++ b/tests/test_med_volume.py
@@ -347,7 +347,7 @@ class TestMedicalVolume(unittest.TestCase):
         )
         assert mv2.is_identical(mv)
 
-    @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
+    @unittest.skipIf(not ututils.is_data_available("qdess"), "unittest data is not available")
     def test_to_from_sitk_dicom_convention(self):
         dp = ututils.get_scan_dirpath("qdess")
         dirpath = ututils.get_read_paths(dp, ImageDataFormat.dicom)[0]

--- a/tests/util.py
+++ b/tests/util.py
@@ -25,12 +25,13 @@ TEMP_PATH = os.path.join(
     UNITTEST_SCANDATA_PATH, f"temp-{str(uuid.uuid1())}-{str(uuid.uuid4())}"
 )  # should be used when for writing with assert_raises clauses
 
-SCANS = ["qdess", "mapss", "cubequant", "cones"]
+SCANS = ["qdess", "mapss", "cubequant", "cones", "enhanced"]
 SCANS_INFO = {
     "mapss": {"expected_num_echos": 7},
     "qdess": {"expected_num_echos": 2},
     "cubequant": {"expected_num_echos": 4},
     "cones": {"expected_num_echos": 4},
+    "enhanced": {"expected_num_echos": 17},
 }
 
 SCAN_DIRPATHS = [os.path.join(UNITTEST_SCANDATA_PATH, x) for x in SCANS]

--- a/tests/util.py
+++ b/tests/util.py
@@ -42,9 +42,17 @@ DECIMAL_PRECISION = 1  # (+/- 0.1ms)
 _IS_ELASTIX_AVAILABLE = None
 
 
-def is_data_available():
+def is_data_available(scan: str = ""):
     disable_data = os.environ.get("VOXEL_UNITTEST_DISABLE_DATA", "").lower() == "true"
-    return not disable_data and os.path.isdir(UNITTEST_DATA_PATH)
+    if disable_data:
+        return True
+    if scan:
+        return os.path.isdir(os.path.join(UNITTEST_SCANDATA_PATH, scan))
+    else:
+        for test_path in SCAN_DIRPATHS:
+            if not os.path.isdir(test_path):
+                return False
+        return True
 
 
 def get_scan_dirpath(scan: str):

--- a/voxel/io/dicom.py
+++ b/voxel/io/dicom.py
@@ -34,6 +34,59 @@ __all__ = ["DicomReader", "DicomWriter"]
 PATH_LIKE = (str, os.PathLike)
 
 
+def _flatten_data(d, new_dataset=None):
+    """ Flatten a pydicom dataset into a single level dictionary."""
+    if new_dataset is None:
+        new_dataset = pydicom.Dataset()
+        new_dataset.is_little_endian = d.is_little_endian
+        new_dataset.is_implicit_VR = d.is_implicit_VR
+        new_dataset.file_meta = copy.deepcopy(d.file_meta)
+        new_dataset.file_meta.MediaStorageSOPClassUID = '1.2.840.10008.5.1.4.1.1.4' # non-enhanced ClassUID
+        new_dataset.ensure_file_meta()
+    for element in d.iterall():
+        if not isinstance(element.value, pydicom.sequence.Sequence):
+            new_dataset.add(element)
+    return new_dataset
+
+
+def _separate_enhanced_slices(data_in):
+    """ Separate enhanced dicom slices into individual slices. """
+    d = copy.copy(data_in)
+    slice_data = d[(0x5200, 0x9230)]
+    d.pop((0x5200, 0x9230))
+
+    try:
+        d.decompress()
+    except:
+        pass
+
+    pixel_data = d.pixel_array.astype(np.uint16)
+
+    if pixel_data.ndim > 2:
+        pixel_data = pixel_data.transpose([1, 2, 0])
+    else:
+        pixel_data = np.expand_dims(pixel_data, -1)
+
+    d.pop((0x7fe0, 0x0010))
+    header_list = []
+    current_slice = 0
+    for slice_header in slice_data:
+        new_slice_header = _flatten_data(d)
+        _flatten_data(slice_header, new_slice_header)
+        new_slice_header.NumberOfFrames = 1
+        new_slice_header.PixelData = pixel_data[:,:,current_slice].tostring()
+        header_list.append(new_slice_header)
+        current_slice += 1
+    return header_list
+
+
+def _safe_dicom_read(file_path, force=False):
+    """ Read a dicom file without crashing if a non-dicom file is encountered. """
+    try:
+        return pydicom.read_file(file_path, force)
+    except pydicom.errors.InvalidDicomError:
+        return None
+
 class DicomReader(DataReader):
     """A class for reading DICOM files.
 
@@ -211,7 +264,8 @@ class DicomReader(DataReader):
                 Dicom file(s) can either be the path or the bytes from the opened file.
             group_by (:obj:`str(s)` or :obj:`int(s)`, optional): DICOM attribute(s) used
                 to group dicoms. This can be the attribute tag name (str) or tag
-                number (int). Defaults to ``self.group_by``.
+                number (int).  For Philips enhanced DICOM datasets,
+                a good choice if the Frame ID: [(0x2005, 0x1011)] Defaults to ``self.group_by``.
             sort_by (:obj:`str(s)` or :obj:`int(s)`, optional): DICOM attribute(s) used
                 to sort dicoms. This sorting is done after sorting files in alphabetical
                 order. Defaults to ``self.sort_by``.
@@ -255,8 +309,11 @@ class DicomReader(DataReader):
                 [path_or_bytes] if not isinstance(path_or_bytes, (list, tuple)) else path_or_bytes
             )
 
+        # Check if dicom file has the group_by element specified in one of the files in an enhanced-safe way
+        temp_dicom = None
+
         if self.num_workers:
-            fn = functools.partial(pydicom.read_file, force=True)
+            fn = functools.partial(_safe_dicom_read, force=True)
             if self.verbose:
                 dicom_slices = process_map(fn, lst_files_dicom, max_workers=self.num_workers)
             else:
@@ -264,15 +321,34 @@ class DicomReader(DataReader):
                     dicom_slices = p.map(fn, lst_files_dicom)
         else:
             dicom_slices = [
-                pydicom.read_file(fp, force=True)
+                _safe_dicom_read(fp, force=True)
                 for fp in tqdm(lst_files_dicom, disable=not self.verbose)
             ]
 
-        # Check if dicom file has the group_by element specified
-        temp_dicom = dicom_slices[0]
-        for _group in group_by:
-            if _group not in temp_dicom:
-                raise KeyError(f"Tag {_group} does not exist in dicom")
+        # remove the failed files from the list
+        dicom_slices = list(filter(lambda x: x is not None, dicom_slices))
+
+        # check if the dicom dataset is enhanced
+        new_dicom_slices = []
+        group_by_checked = False
+        for dataset in dicom_slices:
+            if dataset.file_meta[(2, 2)].value == \
+                    '1.2.840.10008.5.1.4.1.1.4.1':  # Media Storage SOP Class UID == Enhanced MR Image Storage
+                new_dicom_slices.extend(_separate_enhanced_slices(dataset))
+                # check group_by again in case of enhanced dicom.
+                # One might check to do it once only but it's a very small performance penalty
+                for _group in group_by:
+                    if _group not in new_dicom_slices[0]:
+                        raise KeyError(f"Tag {_group} does not exist in dicom")
+            else:
+                if not group_by_checked:
+                    for _group in group_by:
+                        if _group not in dataset:
+                            raise KeyError(f"Tag {_group} does not exist in dicom")
+                    group_by_checked = True
+                new_dicom_slices.append(dataset)
+
+        dicom_slices = new_dicom_slices
 
         if sort_by:
             try:

--- a/voxel/med_volume.py
+++ b/voxel/med_volume.py
@@ -397,7 +397,7 @@ class MedicalVolume(NDArrayOperatorsMixin):
                 raise ValueError(
                     "Shapes not equal: {}, {}".format(self._volume.shape, mv._volume.shape)
                 )
-            assert False  # should not reach here
+            raise AssertionError()  # should not reach here
 
         return out
 


### PR DESCRIPTION
Hi,
This PR adds some support for reading enhanced dicoms in pyvoxel. It separates one single enhanced dicom file into multiple "non-enhanced" datasets while reading, so the output will be non-enhanced. Support might be partial, but it seems to work at least for Philips MR datasets.
I updated the test suite to test it. You should create an "enhanced" subfolder in the "unittest-data/scans" folder and putting inside the multiecho spin echo enhanced dataset which you can find here: https://github.com/muscle-bids/muscle-bids/raw/main/dicom.zip ("Philips_MESE_T2.dcm" inside the zip).

I also made some minor fixes (in the first commit) to make sure that all the formatting checks and tests would run consistently (I don't have all the data you use for testing, so the tests were crashing when they were not finding the right folders where they expected them).

I have been using this approach consistently for a while now, although it was initially based on an older DOSMA implementation, abd this PR seems not to break anything, but it is quite a change in the core functionality, so please have a careful look.